### PR TITLE
fix: the default value of before router change should be null

### DIFF
--- a/front/src/pages/modules/views/AppAppBar.js
+++ b/front/src/pages/modules/views/AppAppBar.js
@@ -186,7 +186,7 @@ AppAppBar.propTypes = {
 
 AppAppBar.defaultProps = {
   // set default props
-  beforeRouteChange: () => {},
+  beforeRouteChange: null,
 };
 
 export default withStyles(styles)(AppAppBar);


### PR DESCRIPTION
- false is expected to return when no beforeRouteChange function was passed in